### PR TITLE
Update notification_smart_motion_event.yaml with Android Alert Once logic

### DIFF
--- a/blueprints/automation/unifiprotect/notification_ring_event.yaml
+++ b/blueprints/automation/unifiprotect/notification_ring_event.yaml
@@ -236,12 +236,17 @@ action:
         tag: "{{ notification_tag }}"
         # Android notification Channel
         channel: "{{ notification_channel }}"
-        # Android high prority
+        # Android high priority
         ttl: 0
         priority: high
         # Android alert once (requires tag to be set)
-        alert_once: {{ (tag != "") | string | lower }}
-        # iOS high prority
+        alert_once: |
+          {% if tag != "" %}
+            true
+          {% else %}
+            false
+          {% endif %}
+        # iOS high priority
         time-sensitive: 1
         image: "{{ notification_image }}"
         # only for iOS
@@ -275,12 +280,17 @@ action:
                 tag: "{{ notification_tag }}"
                 # Android notification Channel
                 channel: "{{ notification_channel }}"
-                # Android high prority
+                # Android high priority
                 ttl: 0
                 priority: high
                 # Android alert once (requires tag to be set)
-                alert_once: {{ (tag != "") | string | lower }}
-                # iOS high prority
+                alert_once: |
+                  {% if tag != "" %}
+                    true
+                  {% else %}
+                    false
+                  {% endif %}
+                # iOS high priority
                 time-sensitive: 1
                 image: "{{ notification_image }}"
                 video: "/api/unifiprotect/video/{{ config_entry_id(entity_id) }}/{{ entity_id }}/{{ (as_datetime(video_end) - timedelta(seconds=input_video_cutoff)).isoformat() }}/{{ video_end }}"

--- a/blueprints/automation/unifiprotect/notification_ring_event.yaml
+++ b/blueprints/automation/unifiprotect/notification_ring_event.yaml
@@ -239,6 +239,8 @@ action:
         # Android high prority
         ttl: 0
         priority: high
+        # Android alert once (requires tag to be set)
+        alert_once: {{ (tag != "") | string | lower }}
         # iOS high prority
         time-sensitive: 1
         image: "{{ notification_image }}"
@@ -276,6 +278,8 @@ action:
                 # Android high prority
                 ttl: 0
                 priority: high
+                # Android alert once (requires tag to be set)
+                alert_once: {{ (tag != "") | string | lower }}
                 # iOS high prority
                 time-sensitive: 1
                 image: "{{ notification_image }}"

--- a/blueprints/automation/unifiprotect/notification_smart_licenseplate_event.yaml
+++ b/blueprints/automation/unifiprotect/notification_smart_licenseplate_event.yaml
@@ -198,12 +198,17 @@ action:
         tag: "{{ notification_tag }}"
         # Android notification Channel
         channel: "{{ notification_channel }}"
-        # Android high prority
+        # Android high priority
         ttl: 0
         priority: high
         # Android alert once (requires tag to be set)
-        alert_once: {{ (tag != "") | string | lower }}
-        # iOS high prority
+        alert_once: |
+          {% if tag != "" %}
+            true
+          {% else %}
+            false
+          {% endif %}
+        # iOS high priority
         time-sensitive: 1
         image: "{{ notification_image }}"
         # only for iOS
@@ -244,12 +249,17 @@ action:
                 tag: "{{ notification_tag }}"
                 # Android notification Channel
                 channel: "{{ notification_channel }}"
-                # Android high prority
+                # Android high priority
                 ttl: 0
                 priority: high
                 # Android alert once (requires tag to be set)
-                alert_once: {{ (tag != "") | string | lower }}
-                # iOS high prority
+                alert_once: |
+                  {% if tag != "" %}
+                    true
+                  {% else %}
+                    false
+                  {% endif %}
+                # iOS high priority
                 time-sensitive: 1
                 image: "{{ notification_image }}"
                 video: "/api/unifiprotect/video/{{ config_entry_id(entity_id) }}/{{ entity_id }}/{{ video_start }}/{{ states[entity_id].last_changed.isoformat() }}"

--- a/blueprints/automation/unifiprotect/notification_smart_licenseplate_event.yaml
+++ b/blueprints/automation/unifiprotect/notification_smart_licenseplate_event.yaml
@@ -201,6 +201,8 @@ action:
         # Android high prority
         ttl: 0
         priority: high
+        # Android alert once (requires tag to be set)
+        alert_once: {{ (tag != "") | string | lower }}
         # iOS high prority
         time-sensitive: 1
         image: "{{ notification_image }}"
@@ -245,6 +247,8 @@ action:
                 # Android high prority
                 ttl: 0
                 priority: high
+                # Android alert once (requires tag to be set)
+                alert_once: {{ (tag != "") | string | lower }}
                 # iOS high prority
                 time-sensitive: 1
                 image: "{{ notification_image }}"

--- a/blueprints/automation/unifiprotect/notification_smart_motion_event.yaml
+++ b/blueprints/automation/unifiprotect/notification_smart_motion_event.yaml
@@ -193,12 +193,7 @@ action:
         ttl: 0
         priority: high
         # Android alert once (requires tag to be set)
-        alert_once: |
-          {% if tag != "" %}
-            true
-          {% else %}
-            false
-          {% endif %}
+        alert_once: {{ (tag != "") | string | lower }}
         # iOS high prority
         time-sensitive: 1
         image: "{{ notification_image }}"
@@ -244,12 +239,7 @@ action:
                 ttl: 0
                 priority: high
                 # Android alert once (requires tag to be set)
-                alert_once: |
-                  {% if tag != "" %}
-                    true
-                  {% else %}
-                    false
-                  {% endif %}             
+                alert_once: {{ (tag != "") | string | lower }}
                 # iOS high prority
                 time-sensitive: 1
                 image: "{{ notification_image }}"

--- a/blueprints/automation/unifiprotect/notification_smart_motion_event.yaml
+++ b/blueprints/automation/unifiprotect/notification_smart_motion_event.yaml
@@ -251,12 +251,17 @@ action:
         tag: "{{ notification_tag }}"
         # Android notification Channel
         channel: "{{ notification_channel }}"
-        # Android high prority
+        # Android high priority
         ttl: 0
         priority: high
         # Android alert once (requires tag to be set)
-        alert_once: {{ (tag != "") | string | lower }}
-        # iOS high prority
+        alert_once: |
+          {% if tag != "" %}
+            true
+          {% else %}
+            false
+          {% endif %}
+        # iOS high priority
         time-sensitive: 1
         image: "{{ notification_image }}"
         # only for iOS
@@ -297,12 +302,17 @@ action:
                 tag: "{{ notification_tag }}"
                 # Android notification Channel
                 channel: "{{ notification_channel }}"
-                # Android high prority
+                # Android high priority
                 ttl: 0
                 priority: high
                 # Android alert once (requires tag to be set)
-                alert_once: {{ (tag != "") | string | lower }}
-                # iOS high prority
+                alert_once: |
+                  {% if tag != "" %}
+                    true
+                  {% else %}
+                    false
+                  {% endif %}
+                # iOS high priority
                 time-sensitive: 1
                 image: "{{ notification_image }}"
                 video: "/api/unifiprotect/video/{{ config_entry_id(entity_id) }}/{{ entity_id }}/{{ video_start }}/{{ states[entity_id].last_changed.isoformat() }}"

--- a/blueprints/automation/unifiprotect/notification_smart_motion_event.yaml
+++ b/blueprints/automation/unifiprotect/notification_smart_motion_event.yaml
@@ -192,6 +192,13 @@ action:
         # Android high prority
         ttl: 0
         priority: high
+        # Android alert once (requires tag to be set)
+        alert_once: |
+          {% if tag != "" %}
+            true
+          {% else %}
+            false
+          {% endif %}
         # iOS high prority
         time-sensitive: 1
         image: "{{ notification_image }}"
@@ -236,6 +243,13 @@ action:
                 # Android high prority
                 ttl: 0
                 priority: high
+                # Android alert once (requires tag to be set)
+                alert_once: |
+                  {% if tag != "" %}
+                    true
+                  {% else %}
+                    false
+                  {% endif %}             
                 # iOS high prority
                 time-sensitive: 1
                 image: "{{ notification_image }}"


### PR DESCRIPTION
Resolves #7.

Test environment:
- Home Assistant 2023.6.3
- Supervisor 2023.06.2
- Operating System 10.3
- Frontend 20230608.0 - latest

Test devices:
- Samsung Galaxy S23 Ultra
- Samsung Galaxy S23+
- Samsung Galaxy Watch5 Pro

Adds Alert Once logic to Android notifications so updates to a smart detection notification do not trigger additional alerts on Android devices. Alert Once requires notification tags to function, so the if/else logic only sets Alert Once to true if the user has set a value for tag.

Not tested on iOS. I do not have access to any iOS devices, though this setting is Android-only so the expected impact is nil.