### PR TITLE
Support for HA Alarm entity & arm states

### DIFF
--- a/blueprints/automation/unifiprotect/notification_smart_motion_event.yaml
+++ b/blueprints/automation/unifiprotect/notification_smart_motion_event.yaml
@@ -17,7 +17,7 @@ blueprint:
       - Notification target for the [mobile app notification target][1].
       - Presence filter - list of mobile phones or other entities that should be within the "home" zone
       - Alarm entity to check arm states.
-      - Alarm arm states when the notifications should work.
+      - Alarm arm states when the notifications should work. Required if alarm entity is selected.
       - Time formatting strings. Timestamp is injected into the notification in case the notification is delay.
       - Cooldown before sending another notification
       - Silence timer for muting notifications via Actionable Notification (docs: [Mobile][2])
@@ -65,9 +65,9 @@ blueprint:
           domain: alarm_control_panel
 
     alarm_arm_states:
-      name: (Optional) Alarm Arm States
-      description: Select the alarm arm states for which you want to receive notifications.
-      default: []
+      name: Alarm Arm States
+      description: Select the alarm arm states for which you want to receive notifications. Required if an Alarm Entity is set.
+      default: ["armed_away", "armed_home", "armed_night", "armed_vacation", "armed_custom_bypass"]
       selector:
         select:
           options:
@@ -206,18 +206,40 @@ trigger:
 condition:
   condition: and
   conditions:
+    # Ensure either input_alarm_entity is not provided or both are provided and state is valid.
     - condition: or
       conditions:
+        # Case when alarm entity is not provided (making it optional)
         - condition: template
           value_template: "{{ input_alarm_entity is not defined or input_alarm_entity == '' }}"
-        - condition: template
-          value_template: "{{ states(input_alarm_entity) in input_alarm_arm_states }}"
+        
+        # Case when both are provided and state is valid
+        - condition: and
+          conditions:
+            # Ensure alarm entity is provided
+            - condition: template
+              value_template: "{{ input_alarm_entity is defined and input_alarm_entity != '' }}"
+            
+            # Ensure alarm arm states is provided and has items
+            - condition: template
+              value_template: "{{ input_alarm_arm_states is defined and input_alarm_arm_states | length > 0 }}"
+            
+            # Ensure current state of alarm entity is in the selected states
+            - condition: template
+              value_template: "{{ states(input_alarm_entity) in input_alarm_arm_states }}"
+
+    # Handle presence filter logic
     - condition: or
       conditions:
+        # Case when presence filter is not provided (making it optional)
         - condition: template
           value_template: "{{ input_presence_filter is not defined or input_presence_filter == '' }}"
+        
+        # Ensure no user is home if presence filter is defined
         - condition: template
           value_template: "{{ (input_presence_filter | select('is_state', 'home') | list | count) == 0 }}"
+
+
 
 action:
   - service: "{{ input_notify_target_app }}"

--- a/blueprints/automation/unifiprotect/notification_smart_motion_event.yaml
+++ b/blueprints/automation/unifiprotect/notification_smart_motion_event.yaml
@@ -18,23 +18,23 @@ blueprint:
       - Presence filter - list of mobile phones or other entities that should be within the "home" zone
       - Alarmo integration entity to check arm states.
       - Alarmo arm states when the notifications should work. 
-      - Time formatting strings. Timestamp is injected into the notification in case the notification is delay.
+      - Time formatting strings. A timestamp is injected into the notification in case the notification is delayed.
       - Cooldown before sending another notification
       - Silence timer for muting notifications via Actionable Notification (docs: [Mobile][2])
       - Configurable lovelace view from notification
 
-      Presence filter works together with Alarmo (you can choose presence filter or Alarmo, you can choose both or nothing at all).
+      The presence filter works together with Alarmo (you can choose presence filter or Alarmo, you can choose both or nothing at all).
 
     ### Requirements
 
     To take full effect of this automation blueprint, your Home Assistant instance needs some setup beforehand.
 
-    - An UniFi Protect camera. Only cameras that are capable of smart detections (G4, AI or G5 Series cameras) will have objection detection sensors.
+    - An UniFi Protect camera. Only cameras that are capable of smart detections (G4, AI, or G5 Series cameras) will have objection detection sensors.
     - A valid HTTPS certificate and [properly configured external URL][3]
       - If you are using Home Assistant Cloud, this is already set up for you.
-      - If this is not setup correctly, the actionable notifications and attachments will not appear in the notifications.
+      - If this is not set up correctly, the actionable notifications and attachments will not appear in the notifications.
       - You do not need your _whole_ Home Assistant to be publicly accessible. Only the paths `/api/unifiprotect/*` and
-        `/api/webhook/*` need to be accessible outside of your network.
+        `/api/webhook/*` needs to be accessible outside of your network.
 
     [1]: https://companion.home-assistant.io/docs/notifications/notifications-basic#sending-notifications-to-multiple-devices
     [2]: https://companion.home-assistant.io/docs/notifications/actionable-notifications/
@@ -122,7 +122,7 @@ blueprint:
       name: (Optional) Silence Notifications
       description: >
         How long to silence notifications for this camera when requested as part of the
-        actionable notification. The time interval you have to respond to the slient
+        actionable notification. The time interval you have to respond to the silent
         action is controlled by "Cooldown". Short Cooldown timers may prevent you from
         silencing.
       default: 30
@@ -134,7 +134,7 @@ blueprint:
     lovelace_view:
       name: (Optional) Lovelace View
       description: |
-        Home Assistant Lovelace view to open when clicking notification.
+        Home Assistant Lovelace view to open when clicking the notification.
         If left blank, URI Notification actions will not be generated.
       default: ""
       selector:
@@ -142,7 +142,7 @@ blueprint:
     debug_event_id:
       name: (Optional) Debug Event ID
       description: >
-        Debug Event ID for UniFi Protect to use for when manually triggering automation.
+        Debug Event ID for UniFi Protect to use when manually triggering automation.
         Will be used to generate a thumbnail for testing notifications.
       default: ""
       selector:
@@ -204,32 +204,20 @@ trigger:
     to: "on"
 
 condition:
-  condition: or
+  condition: and
   conditions:
-    - condition: and
-      conditions:
-        - condition: template
-          value_template: "{{ input_alarmo_entity is defined and input_alarmo_entity != '' }}"
-        - condition: template
-          value_template: "{{ states(input_alarmo_entity) in input_alarmo_arm_states }}"
-        - condition: template
-          value_template: "{{ not input_presence_filter or (input_presence_filter | select('is_state', 'home') | list | count) == 0 }}"
-    - condition: and
+    - condition: or
       conditions:
         - condition: template
           value_template: "{{ input_alarmo_entity is not defined or input_alarmo_entity == '' }}"
         - condition: template
-          value_template: "{{ not input_presence_filter or (input_presence_filter | select('is_state', 'home') | list | count) == 0 }}"
-    - condition: and
-      conditions:
-        - condition: template
-          value_template: "{{ input_alarmo_entity is defined and input_alarmo_entity != '' }}"
-        - condition: template
           value_template: "{{ states(input_alarmo_entity) in input_alarmo_arm_states }}"
-    - condition: and
+    - condition: or
       conditions:
         - condition: template
-          value_template: "{{ not input_presence_filter or (input_presence_filter | select('is_state', 'home') | list | count) == 0 }}"
+          value_template: "{{ input_presence_filter is not defined or input_presence_filter == '' }}"
+        - condition: template
+          value_template: "{{ (input_presence_filter | select('is_state', 'home') | list | count) == 0 }}"
 
 action:
   - service: "{{ input_notify_target_app }}"

--- a/blueprints/automation/unifiprotect/notification_smart_motion_event.yaml
+++ b/blueprints/automation/unifiprotect/notification_smart_motion_event.yaml
@@ -15,10 +15,15 @@ blueprint:
     ### Optional Settings
 
       - Notification target for the [mobile app notification target][1].
+      - Presence filter - list of mobile phones or other entities that should be within the "home" zone
+      - Alarmo integration entity to check arm states.
+      - Alarmo arm states when the notifications should work. 
       - Time formatting strings. Timestamp is injected into the notification in case the notification is delay.
       - Cooldown before sending another notification
       - Silence timer for muting notifications via Actionable Notification (docs: [Mobile][2])
       - Configurable lovelace view from notification
+
+      Presence filter works together with Alarmo (you can choose presence filter or Alarmo, you can choose both or nothing at all).
 
     ### Requirements
 
@@ -51,6 +56,26 @@ blueprint:
       selector:
         entity:
           domain: device_tracker
+          multiple: true
+    alarmo_entity:
+      name: Alarmo Entity
+      description: The Alarmo entity to monitor for state changes.
+      selector:
+        entity:
+          domain: alarm_control_panel
+          integration: alarmo
+    alarmo_arm_states:
+      name: Alarmo Arm States
+      description: Select the Alarmo arm states for which you want to receive notifications.
+      default: []
+      selector:
+        select:
+          options:
+            - armed_away
+            - armed_home
+            - armed_night
+            - armed_vacation
+            - armed_custom_bypass
           multiple: true
     notify_target_app:
       name: (Optional) Notification Target (Mobile App)
@@ -135,6 +160,8 @@ variables:
   input_silence_timer: !input silence_timer
   input_time_format: !input time_format
   input_presence_filter: !input presence_filter
+  input_alarmo_entity: !input alarmo_entity
+  input_alarmo_arm_states: !input alarmo_arm_states
   input_debug_event_id: !input debug_event_id
   input_cooldown: !input cooldown
   lovelace_view: "{{ input_lovelace_view | trim }}"
@@ -177,7 +204,32 @@ trigger:
     to: "on"
 
 condition:
-  - "{{ not input_presence_filter or (input_presence_filter | select('is_state', 'home') | list | count) == 0 }}"
+  condition: or
+  conditions:
+    - condition: and
+      conditions:
+        - condition: template
+          value_template: "{{ input_alarmo_entity is defined and input_alarmo_entity != '' }}"
+        - condition: template
+          value_template: "{{ states(input_alarmo_entity) in input_alarmo_arm_states }}"
+        - condition: template
+          value_template: "{{ not input_presence_filter or (input_presence_filter | select('is_state', 'home') | list | count) == 0 }}"
+    - condition: and
+      conditions:
+        - condition: template
+          value_template: "{{ input_alarmo_entity is not defined or input_alarmo_entity == '' }}"
+        - condition: template
+          value_template: "{{ not input_presence_filter or (input_presence_filter | select('is_state', 'home') | list | count) == 0 }}"
+    - condition: and
+      conditions:
+        - condition: template
+          value_template: "{{ input_alarmo_entity is defined and input_alarmo_entity != '' }}"
+        - condition: template
+          value_template: "{{ states(input_alarmo_entity) in input_alarmo_arm_states }}"
+    - condition: and
+      conditions:
+        - condition: template
+          value_template: "{{ not input_presence_filter or (input_presence_filter | select('is_state', 'home') | list | count) == 0 }}"
 
 action:
   - service: "{{ input_notify_target_app }}"

--- a/blueprints/automation/unifiprotect/notification_smart_motion_event.yaml
+++ b/blueprints/automation/unifiprotect/notification_smart_motion_event.yaml
@@ -16,25 +16,25 @@ blueprint:
 
       - Notification target for the [mobile app notification target][1].
       - Presence filter - list of mobile phones or other entities that should be within the "home" zone
-      - Alarmo integration entity to check arm states.
-      - Alarmo arm states when the notifications should work. 
-      - Time formatting strings. A timestamp is injected into the notification in case the notification is delayed.
+      - Alarm entity to check arm states.
+      - Alarm arm states when the notifications should work.
+      - Time formatting strings. Timestamp is injected into the notification in case the notification is delay.
       - Cooldown before sending another notification
       - Silence timer for muting notifications via Actionable Notification (docs: [Mobile][2])
       - Configurable lovelace view from notification
 
-      The presence filter works together with Alarmo (you can choose presence filter or Alarmo, you can choose both or nothing at all).
+      The presence filter works together with the alarm entity (you can choose presence filter or alarm entity, you can choose both or nothing at all).
 
     ### Requirements
 
     To take full effect of this automation blueprint, your Home Assistant instance needs some setup beforehand.
 
-    - An UniFi Protect camera. Only cameras that are capable of smart detections (G4, AI, or G5 Series cameras) will have objection detection sensors.
+    - An UniFi Protect camera. Only cameras that are capable of smart detections (G4, AI or G5 Series cameras) will have objection detection sensors.
     - A valid HTTPS certificate and [properly configured external URL][3]
       - If you are using Home Assistant Cloud, this is already set up for you.
-      - If this is not set up correctly, the actionable notifications and attachments will not appear in the notifications.
+      - If this is not setup correctly, the actionable notifications and attachments will not appear in the notifications.
       - You do not need your _whole_ Home Assistant to be publicly accessible. Only the paths `/api/unifiprotect/*` and
-        `/api/webhook/*` needs to be accessible outside of your network.
+        `/api/webhook/*` need to be accessible outside of your network.
 
     [1]: https://companion.home-assistant.io/docs/notifications/notifications-basic#sending-notifications-to-multiple-devices
     [2]: https://companion.home-assistant.io/docs/notifications/actionable-notifications/
@@ -57,16 +57,16 @@ blueprint:
         entity:
           domain: device_tracker
           multiple: true
-    alarmo_entity:
-      name: Alarmo Entity
-      description: The Alarmo entity to monitor for state changes.
+    alarm_entity:
+      name: (Optional) Alarm Entity
+      description: The alarm entity to monitor for state changes.
       selector:
         entity:
           domain: alarm_control_panel
-          integration: alarmo
-    alarmo_arm_states:
-      name: Alarmo Arm States
-      description: Select the Alarmo arm states for which you want to receive notifications.
+
+    alarm_arm_states:
+      name: (Optional) Alarm Arm States
+      description: Select the alarm arm states for which you want to receive notifications.
       default: []
       selector:
         select:
@@ -122,7 +122,7 @@ blueprint:
       name: (Optional) Silence Notifications
       description: >
         How long to silence notifications for this camera when requested as part of the
-        actionable notification. The time interval you have to respond to the silent
+        actionable notification. The time interval you have to respond to the slient
         action is controlled by "Cooldown". Short Cooldown timers may prevent you from
         silencing.
       default: 30
@@ -134,7 +134,7 @@ blueprint:
     lovelace_view:
       name: (Optional) Lovelace View
       description: |
-        Home Assistant Lovelace view to open when clicking the notification.
+        Home Assistant Lovelace view to open when clicking notification.
         If left blank, URI Notification actions will not be generated.
       default: ""
       selector:
@@ -142,7 +142,7 @@ blueprint:
     debug_event_id:
       name: (Optional) Debug Event ID
       description: >
-        Debug Event ID for UniFi Protect to use when manually triggering automation.
+        Debug Event ID for UniFi Protect to use for when manually triggering automation.
         Will be used to generate a thumbnail for testing notifications.
       default: ""
       selector:
@@ -160,8 +160,8 @@ variables:
   input_silence_timer: !input silence_timer
   input_time_format: !input time_format
   input_presence_filter: !input presence_filter
-  input_alarmo_entity: !input alarmo_entity
-  input_alarmo_arm_states: !input alarmo_arm_states
+  input_alarm_entity: !input alarm_entity
+  input_alarm_arm_states: !input alarm_arm_states
   input_debug_event_id: !input debug_event_id
   input_cooldown: !input cooldown
   lovelace_view: "{{ input_lovelace_view | trim }}"
@@ -209,9 +209,9 @@ condition:
     - condition: or
       conditions:
         - condition: template
-          value_template: "{{ input_alarmo_entity is not defined or input_alarmo_entity == '' }}"
+          value_template: "{{ input_alarm_entity is not defined or input_alarm_entity == '' }}"
         - condition: template
-          value_template: "{{ states(input_alarmo_entity) in input_alarmo_arm_states }}"
+          value_template: "{{ states(input_alarm_entity) in input_alarm_arm_states }}"
     - condition: or
       conditions:
         - condition: template


### PR DESCRIPTION
This pull request allows you to integrate your home alarm system through Alarmo integration. It allows to specify Alarmo entity panel and arm states that act as filters as to when to send notifications. The code respects the presence filter and works together. You can specify the presence filter and/or Alarmo entity.

This helped me to unblock several additional use cases:

1.  When I & my family are away and someone is looking after the home, it does not send us a notification every time the person is in camera fields, only if the home is armed. (previously, I had to disable automation)
2. If the home is armed for a night, I receive notification if someone is on the territory (duplicate of the automation with presence filter off, but respecting "night arm")
3. When both the presence filter and Alarmo are enabled, it doesn't send any notifications to you while you are leaving or entering the house even if an alarm is set.
