### PR TITLE
Update Alarm Entity and Alarm Arm State defaults

### DIFF
--- a/blueprints/automation/unifiprotect/notification_smart_motion_event.yaml
+++ b/blueprints/automation/unifiprotect/notification_smart_motion_event.yaml
@@ -59,6 +59,7 @@ blueprint:
           multiple: true
     alarm_entity:
       name: (Optional) Alarm Entity
+      default: ""
       description: The alarm entity to monitor for state changes.
       selector:
         entity:


### PR DESCRIPTION
Add a blank default selector to Alarm Entity so the blueprint will work when an alarm entity is not selected. This makes `(Optional) Alarm Entity` optional as intended.

Resolves #10 